### PR TITLE
do NOT prefix https:// push-url

### DIFF
--- a/public/js/timermanager.js
+++ b/public/js/timermanager.js
@@ -182,7 +182,7 @@
   	function pushURL(sel) {
                 var url=prompt("URL:","");
                 var prefix = 'http://';
-                if (url.substr(0, prefix.length) !== prefix)
+                if (!url.match(/^http/))	// do NOT prefix https:// urls
                 {
                         url = prefix + url;
                 }


### PR DESCRIPTION
As www.digitalrock.de uses now always https, it fails if you enter eg. https://www.digitalrock.de/egroupware/ranking/beamer.php